### PR TITLE
feat(accessibility): enhanced keyboard accessbility and form states

### DIFF
--- a/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.component.scss
+++ b/projects/cashmere-examples/src/lib/chip-singlerow/chip-singlerow-example.component.scss
@@ -1,6 +1,5 @@
 :host {
     display: block;
-    overflow: hidden;
 }
 
 .chip-row-wrapper {

--- a/projects/cashmere-examples/src/project-template/src/styles.scss
+++ b/projects/cashmere-examples/src/project-template/src/styles.scss
@@ -15,6 +15,10 @@ $hc-icons-font-path: 'node_modules/@healthcatalyst/cashmere/hcicons';
     margin-right: 10px !important;
 }
 
+hc-example-viewer .hc-tab-content-horizontal {
+    padding: 3px;
+}
+
 .pipe-output {
     font-weight: 600px;
     font-size: 22px;

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.html
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.html
@@ -5,7 +5,6 @@
                [id]="_inputId"
                [attr.value]="value"
                [attr.name]="name"
-               [tabIndex]="tabIndex"
                [indeterminate]="indeterminate"
                [disabled]="disabled"
                [required]="required"
@@ -13,7 +12,7 @@
                (change)="_stopChangeEvent($event)"
                (click)="_clickEvent($event)"
                (blur)="_onBlur()"/>
-        <label class="hc-checkbox-overlay" [attr.for]="_inputId"></label>
+        <label class="hc-checkbox-overlay" [attr.for]="_inputId" [tabIndex]="tabIndex" (keydown.space)="_clickEvent($event); $event.preventDefault();"></label>
         <label class="hc-checkbox-label" [ngClass]="'hc-checkbox-align-label-'+align" [attr.for]="_inputId">
             <ng-content></ng-content>
         </label>

--- a/projects/cashmere/src/lib/checkbox/checkbox.component.scss
+++ b/projects/cashmere/src/lib/checkbox/checkbox.component.scss
@@ -67,10 +67,6 @@
         @include hc-checkbox-overlay-indeterminate();
     }
 
-    .hc-checkbox-indeterminate:hover & {
-        @include hc-checkbox-indeterminate-hover();
-    }
-
     .hc-checkbox-indeterminate .hc-checkbox-tight & {
         @include hc-checkbox-overlay-indeterminate-tight();
     }
@@ -82,13 +78,27 @@
     .hc-checkbox-disabled input[type=checkbox] + & {
         @include hc-checkbox-overlay-disabled();
     }
+
+    &:focus {
+        @include hc-checkbox-overlay-focus();
+    }
 }
 
 .hc-form-field-invalid {
     .hc-checkbox-overlay {
         @include hc-checkbox-invalid();
+
+        &:focus {
+            @include hc-checkbox-overlay-focus-invalid();
+        }
+    }
+
+    input[type='checkbox']:checked + .hc-checkbox-overlay {
+        @include hc-checkbox-overlay-checked-invalid();
     }
 }
+
+
 
 .hc-checkbox-stub {
     .hc-checkbox-label, .hc-checkbox-overlay {

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.html
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.html
@@ -18,6 +18,7 @@
             [class.hc-form-field-flex]="!inline"
             [class.hc-form-field-flex-inline]="inline"
             [class.hc-form-field-invalid]="_shouldShowErrorMessages()"
+            [class.hc-form-field-flex-focused]="_hasFocusedInput"
         >
             <div class="hc-form-field-prefix" *ngIf="_prefixChildren.length">
                 <ng-content select="[hcPrefix]"></ng-content>

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.scss
@@ -23,6 +23,14 @@
 .hc-form-field-flex {
     @include hc-form-field-flex();
 
+    &:hover {
+        @include hc-form-field-flex-hover();
+    }
+
+    &.hc-form-field-flex-focused {
+        @include hc-form-field-flex-focus();
+    }
+
     .hc-form-field-disabled & {
         @include hc-form-field-disabled-flex();
     }
@@ -30,6 +38,14 @@
 
 .hc-form-field-flex-inline {
     @include hc-form-field-flex-inline();
+
+    &:hover {
+        @include hc-form-field-flex-hover();
+    }
+
+    &.hc-form-field-flex-focused {
+        @include hc-form-field-flex-focus();
+    }
 
     .hc-form-field-disabled & {
         @include hc-form-field-disabled-flex();
@@ -39,6 +55,10 @@
 .hc-form-field-invalid.hc-form-field-flex,
 .hc-form-field-invalid.hc-form-field-flex-inline {
     @include hc-form-field-input-invalid();
+
+    &.hc-form-field-flex-focused {
+        @include hc-form-field-input-invalid-focus();
+    }
 }
 
 .hc-form-field-non-input {

--- a/projects/cashmere/src/lib/form-field/hc-form-field.component.ts
+++ b/projects/cashmere/src/lib/form-field/hc-form-field.component.ts
@@ -73,6 +73,8 @@ export class HcFormFieldComponent implements AfterContentInit, OnDestroy {
         return !!this._inputChildren.length;
     }
 
+    public _hasFocusedInput = false;
+
     /** Whether the form elements should be stacked (default), or inline */
     @Input()
     get inline(): boolean {
@@ -102,6 +104,13 @@ export class HcFormFieldComponent implements AfterContentInit, OnDestroy {
             this._updateTightControls();
             // Pass the current tight setting to controls that are added dynamically to the FormField
             this._controls.changes.pipe(takeUntil(this.unsubscribe$)).subscribe(() => this._updateTightControls());
+        }
+
+        // wire up focus listener for hcInputs
+        if (this.hasInput) {
+            this._inputChildren.first.focusChanged.pipe(takeUntil(this.unsubscribe$)).subscribe(focused => {
+                this._hasFocusedInput = focused;
+            });
         }
     }
 

--- a/projects/cashmere/src/lib/input/input.directive.ts
+++ b/projects/cashmere/src/lib/input/input.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, DoCheck, ElementRef, HostBinding, HostListener, Input, Optional, Self, forwardRef} from '@angular/core';
+import {Directive, DoCheck, ElementRef, HostBinding, HostListener, Input, Optional, Self, forwardRef, Output, EventEmitter} from '@angular/core';
 import {parseBooleanAttribute} from '../util';
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {FormGroupDirective, NgControl, NgForm} from '@angular/forms';
@@ -93,6 +93,8 @@ export class InputDirective extends HcFormControlComponent implements DoCheck {
         this._isRequired = parseBooleanAttribute(requiredInput);
     }
 
+    @Output() focusChanged = new EventEmitter<boolean>();
+
     @HostBinding('class.hc-input')
     _hostHcInputClass = true;
 
@@ -171,7 +173,7 @@ export class InputDirective extends HcFormControlComponent implements DoCheck {
     private _changeFocus(focused: boolean) {
         if (this._focused !== focused && !this.readonly) {
             this._focused = focused;
-            // TODO: trigger state change
+            this.focusChanged.emit(focused);
         }
     }
 

--- a/projects/cashmere/src/lib/sass/_menu.scss
+++ b/projects/cashmere/src/lib/sass/_menu.scss
@@ -52,6 +52,8 @@ a.hc-menu-item {
         background-color: tint($blue, 70%);
         color: $offblack;
         cursor: pointer;
+        box-shadow: none;
+        outline: none;
     }
 
     &.hc-menu-item-submenu {

--- a/projects/cashmere/src/lib/sass/_ng-select-theme.scss
+++ b/projects/cashmere/src/lib/sass/_ng-select-theme.scss
@@ -23,8 +23,10 @@ $ng-select-value-font-size: 14px !default;
 
 .ng-select {
     &.ng-select-opened {
-        > .ng-select-container {
+        > .ng-select-container, >.ng-select-container:hover {
             border-color: $ng-select-border-focus;
+            background-color: $white;
+            box-shadow: 0 0 3px $primary-brand;
         }
         &.ng-select-bottom {
             > .ng-select-container {
@@ -42,6 +44,8 @@ $ng-select-value-font-size: 14px !default;
     &.ng-select-focused {
         &:not(.ng-select-opened) > .ng-select-container {
             border-color: $ng-select-border-focus;
+            background-color: $white;
+            box-shadow: 0 0 3px $primary-brand;
         }
     }
     &.ng-select-disabled {
@@ -58,6 +62,12 @@ $ng-select-value-font-size: 14px !default;
         border: $ng-select-border-width solid $ng-select-border;
         min-height: $ng-select-height;
         align-items: center;
+
+        &:hover {
+            border-color: $ng-select-border-focus;
+            background-color: tint($ng-select-border-focus, 95%);
+        }
+
         .ng-value-container {
             line-height: 1.3;
             align-items: center;

--- a/projects/cashmere/src/lib/sass/_radio-group.scss
+++ b/projects/cashmere/src/lib/sass/_radio-group.scss
@@ -13,4 +13,13 @@
     .hc-radio-overlay {
         border-color: $error !important;
     }
+
+    .hc-radio-input:checked ~ .hc-radio-overlay {
+        border-color: $error !important;
+        background-color: $error !important;
+    }
+
+    .hc-radio-input:focus ~ .hc-radio-overlay {
+        box-shadow: 0 0 5px $error !important;
+    }
 }

--- a/projects/cashmere/src/lib/sass/accordion.scss
+++ b/projects/cashmere/src/lib/sass/accordion.scss
@@ -1,3 +1,5 @@
+@import './colors';
+
 $accordion-toolbar-padding: 0 10px;
 $accordion-caret-img: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNi45NzgiIGhlaWdodD0iMTcuMzE5IiB2aWV3Qm94PSIwIDAgMjYuOTc4IDE3LjMxOSI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogIzAwYWVmZjsKICAgICAgfQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHBhdGggaWQ9IlBhdGhfNSIgZGF0YS1uYW1lPSJQYXRoIDUiIGNsYXNzPSJjbHMtMSIgZD0iTTI4LjE3NS0xMi4xODhhMS4wODEsMS4wODEsMCwwLDAsMC0xLjUyM0wyNS40LTE2LjQ3M2ExLjA2MSwxLjA2MSwwLDAsMC0xLjUwNywwTDE1LTcuNTg0bC04Ljg5LTguODlhMS4wNjEsMS4wNjEsMCwwLDAtMS41MDcsMEwxLjgyNS0xMy43MTFhMS4wODEsMS4wODEsMCwwLDAsMCwxLjUyM0wxNC4yNDcuMjE4YTEuMDYxLDEuMDYxLDAsMCwwLDEuNTA3LDBaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMS41MTEgMTYuNzg3KSIvPgo8L3N2Zz4K';
 
@@ -23,11 +25,16 @@ $accordion-caret-img: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy5
     border: none;
     color: deepskyblue;
     cursor: pointer;
-    height: 50px;
+    height: 48px;
     outline: none;
     padding: 0;
     position: relative;
-    width: 50px;
+    width: 48px;
+    margin: 2px;
+    border-radius: 4px;
+    align-items: center;
+    display: flex;
+    justify-content: center;
 
     &::after {
         background-image: url($accordion-caret-img);
@@ -43,12 +50,13 @@ $accordion-caret-img: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy5
         transition: transform 500ms cubic-bezier(0.25, 0.8, 0.25, 1);
         width: 13px;
     }
+
+    &:focus {
+        box-shadow: 0 0 0 2px transparentize($primary-brand, 0.6);
+    }
 }
 
 @mixin hc-accordion-trigger-right() {
-    align-items: center;
-    display: flex;
-    justify-content: center;
     margin-left: auto;
     order: 1;
 }

--- a/projects/cashmere/src/lib/sass/button.scss
+++ b/projects/cashmere/src/lib/sass/button.scss
@@ -13,6 +13,10 @@ $btn-icon-sz: 18px;
     color: $white;
     background-color: $color;
 
+    &:focus {
+        background-color: shade($color, $darken-pct * 2);
+        box-shadow: 0 0 0 3px transparentize($color, 0.6);
+    }
     &:hover {
         background-color: shade($color, $darken-pct);
         color: $white;
@@ -21,6 +25,7 @@ $btn-icon-sz: 18px;
         background-color: shade($color, $darken-pct * 2);
         color: $white;
     }
+
     &[disabled],
     &[disabled]:hover,
     &[disabled]:focus,
@@ -53,8 +58,9 @@ $btn-icon-sz: 18px;
     }
 
     &:focus {
-        outline: 5px auto -webkit-focus-ring-color;
-        outline-offset: -2px;
+        outline: none;
+        border-bottom: none;
+        box-shadow: 0 0 0 2px transparentize($primary-brand, 0.6);
     }
 
     &:active {
@@ -109,6 +115,9 @@ $btn-icon-sz: 18px;
 
     &:hover {
         color: $offblack;
+    }
+    &:focus {
+        box-shadow: 0 0 0 2px transparentize($primary-brand, 0.6);
     }
     &[disabled]:hover {
         color: $gray-600;
@@ -186,6 +195,12 @@ $btn-icon-sz: 18px;
     vertical-align: inherit;
     font-family: inherit;
     border: none;
+
+    &:focus {
+        outline: none;
+        border-radius: 0;
+        box-shadow: 0px 2px 0 0px $primary-brand;
+    }
 }
 
 // Icon button
@@ -205,8 +220,14 @@ $btn-icon-sz: 18px;
     text-decoration: none;
     cursor: pointer;
     white-space: nowrap;
-    text-align: center;
-    vertical-align: baseline;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 0 2px transparentize($primary-brand, 0.6);
+    }
 }
 
 // Split button

--- a/projects/cashmere/src/lib/sass/checkbox.scss
+++ b/projects/cashmere/src/lib/sass/checkbox.scss
@@ -2,7 +2,6 @@
 @import './functions';
 
 @mixin hc-checkbox-container() {
-    overflow: hidden;
     display: flex;
 }
 
@@ -106,14 +105,17 @@
 }
 
 @mixin hc-checkbox-overlay-hover() {
-    border: 2px solid $primary-brand;
+    border: 1px solid $primary-brand;
+    background-color: tint($blue, 95%);
 }
 
-@mixin hc-checkbox-indeterminate-hover() {
-    &:after {
-        top: 3px;
-        left: 3px;
-    }
+@mixin hc-checkbox-overlay-focus() {
+    outline: none;
+    box-shadow: 0 0 5px $primary-brand;
+}
+
+@mixin hc-checkbox-overlay-focus-invalid() {
+    box-shadow: 0 0 5px $error;
 }
 
 @mixin hc-checkbox-overlay-checked() {
@@ -149,6 +151,10 @@
 
 @mixin hc-checkbox-invalid() {
     border-color: $error !important;
+}
+
+@mixin hc-checkbox-overlay-checked-invalid() {
+    background-color: $error;
 }
 
 @mixin hc-checkbox-stubbed() {

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -56,6 +56,18 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     background: $white;
 }
 
+@mixin hc-form-field-flex-hover() {
+    border: 1px solid $primary-brand;
+    background-color: tint($blue, 95%);
+}
+
+@mixin hc-form-field-flex-focus() {
+    border: 1px solid $primary-brand;
+    background-color: $white;
+    box-shadow: 0 0 3px $primary-brand;
+    outline: none;
+}
+
 @mixin hc-form-field-flex-inline() {
     display: inline-flex;
     align-items: center;
@@ -74,6 +86,10 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
 @mixin hc-form-field-input-invalid() {
     border: 1px solid $error;
+}
+
+@mixin hc-form-field-input-invalid-focus() {
+    box-shadow: 0 0 3px $error;
 }
 
 @mixin hc-form-field-non-input() {

--- a/projects/cashmere/src/lib/sass/modal.class.scss
+++ b/projects/cashmere/src/lib/sass/modal.class.scss
@@ -14,6 +14,10 @@
 
 .hc-modal-footer {
     @include hc-modal-footer();
+
+    .hc-button {
+        @include hc-modal-button-footer();
+    }
 }
 
 .hc-modal-content {

--- a/projects/cashmere/src/lib/sass/modal.scss
+++ b/projects/cashmere/src/lib/sass/modal.scss
@@ -93,6 +93,10 @@ $modal-border: 1px solid $gray-200;
     padding: $modal-padding;
 }
 
+@mixin hc-modal-button-footer() {
+    margin-left: 10px;
+}
+
 @mixin hc-modal-content() {
     background-color: $white;
     border-radius: 6px;

--- a/projects/cashmere/src/lib/sass/picklist.scss
+++ b/projects/cashmere/src/lib/sass/picklist.scss
@@ -8,7 +8,6 @@ $pane-header-height: 30px;
     height: 100%;
     justify-content: space-between;
     min-width: 650px;
-    overflow: hidden;
 }
 
 @mixin hc-picklist-pane-wrap() {

--- a/projects/cashmere/src/lib/sass/radio-button.scss
+++ b/projects/cashmere/src/lib/sass/radio-button.scss
@@ -64,7 +64,8 @@
 }
 
 @mixin hc-radio-overlay-hover() {
-    border: 2px solid $primary-brand;
+    border: 1px solid $primary-brand;
+    background-color: tint($blue, 95%);
 }
 
 @mixin hc-radio-overlay-checked() {
@@ -98,8 +99,8 @@
 }
 
 @mixin hc-radio-input-focus {
-    outline: 2px solid lighten($azure, 30);
-    outline-offset: -1px;
+    outline: none;
+    box-shadow: 0 0 5px $primary-brand;
 }
 
 @mixin hc-radio-input-active {

--- a/projects/cashmere/src/lib/sass/scroll-nav.scss
+++ b/projects/cashmere/src/lib/sass/scroll-nav.scss
@@ -26,6 +26,11 @@
     }
 }
 
+@mixin hc-scroll-nav-link-focus {
+    outline: none;
+    box-shadow: 0 0 0 2px transparentize($primary-brand, 0.6);
+}
+
 @mixin hc-scroll-nav-link-active() {
     &,
     &:hover {

--- a/projects/cashmere/src/lib/sass/select.scss
+++ b/projects/cashmere/src/lib/sass/select.scss
@@ -84,6 +84,18 @@
     }
 }
 
+@mixin hc-select-input-hover() {
+    border: 1px solid $primary-brand;
+    background-color: tint($primary-brand, 95%);
+}
+
+@mixin hc-select-input-focus() {
+    border: 1px solid $primary-brand;
+    background-color: $white;
+    box-shadow: 0 0 3px $primary-brand;
+    outline: none;
+}
+
 @mixin hc-select-input-tight() {
     @include fontSize(13px);
     height: 28px;
@@ -95,4 +107,8 @@
 
 @mixin hc-select-input-invalid() {
     border: 1px solid $error;
+}
+
+@mixin hc-select-input-invalid-focus() {
+    box-shadow: 0 0 3px $error;
 }

--- a/projects/cashmere/src/lib/sass/tab.scss
+++ b/projects/cashmere/src/lib/sass/tab.scss
@@ -4,6 +4,15 @@
 
 @mixin hc-tab() {
     min-width: 0;
+
+    &:focus {
+        outline: none;
+
+        a {
+            outline: 2px solid transparentize($primary-brand, 0.6);
+            outline-offset: -2px;
+        }
+    }
 }
 
 @mixin hc-tab-vertical() {
@@ -16,6 +25,11 @@
     &:hover {
         cursor: pointer;
     }
+}
+
+@mixin hc-tab-embedded-anchor-focus() {
+    box-shadow: none;
+    outline: none;
 }
 
 @mixin hc-tab-vertical-active() {

--- a/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav-link.directive.ts
+++ b/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav-link.directive.ts
@@ -10,7 +10,14 @@ export class ScrollNavLinkDirective {
     @HostBinding('class.hc-scroll-nav-link')
     _hostClass = true;
 
+    @HostBinding('attr.tabindex')
+    _hostIndex = 0;
+
     constructor(public _el: ElementRef) {}
+
+    @HostListener('keydown.enter') _onEnter() {
+        this.navigateToSection(this.hcScrollLink);
+    }
 
     @HostListener('click') _onClick() {
         this.navigateToSection(this.hcScrollLink);

--- a/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.scss
+++ b/projects/cashmere/src/lib/scroll-nav/nav/scroll-nav.component.scss
@@ -10,6 +10,10 @@
 
 .hc-scroll-nav-link {
     @include hc-scroll-nav-links();
+
+    &:focus {
+        @include hc-scroll-nav-link-focus();
+    }
 }
 
 .hc-scroll-nav-link-active {

--- a/projects/cashmere/src/lib/select/select.component.scss
+++ b/projects/cashmere/src/lib/select/select.component.scss
@@ -23,8 +23,20 @@
 .hc-select-input {
     @include hc-select-input();
 
+    &:hover {
+        @include hc-select-input-hover();
+    }
+
+    &:focus {
+        @include hc-select-input-focus();
+    }
+
     .hc-form-field-invalid & {
         @include hc-select-input-invalid();
+
+        &:focus {
+            @include hc-select-input-invalid-focus();
+        }
     }
 
     .hc-select-tight & {

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.html
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.html
@@ -1,5 +1,6 @@
 <ng-container *ngIf="_direction">
     <a
+        tabIndex="-1"
         *ngIf="routerLink; else tabWithoutRouting"
         class="hc-tab-{{ _direction }} hc-text-ellipsis"
         [class.hc-tab-tight]="_tight"
@@ -16,6 +17,7 @@
 </ng-container>
 <ng-template #tabWithoutRouting>
     <a
+        tabIndex="-1"
         class="hc-tab-{{ _direction }} hc-text-ellipsis"
         [class.hc-tab-tight]="_tight"
         [class.active]="_active"

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.scss
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.scss
@@ -2,6 +2,11 @@
 
 .hc-tab {
     @include hc-tab();
+
+    // tabs have an anchor element embedded, but we want the user to focus on the parent tab rather than the achor
+    a:focus {
+        @include hc-tab-embedded-anchor-focus();
+    }
 }
 
 .hc-tab-vertical {

--- a/projects/cashmere/src/lib/tabs/tab/tab.component.ts
+++ b/projects/cashmere/src/lib/tabs/tab/tab.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, ContentChildren, QueryList, AfterContentInit, Output, ViewEncapsulation} from '@angular/core';
+import {Component, Input, ContentChildren, QueryList, AfterContentInit, Output, ViewEncapsulation, HostBinding, HostListener} from '@angular/core';
 import {EventEmitter, TemplateRef, ViewChild} from '@angular/core';
 import {HcTabTitleComponent} from './tab-title.component';
 import {Params} from '@angular/router';
@@ -33,6 +33,9 @@ export class TabComponent implements AfterContentInit {
     @Output()
     tabClick: EventEmitter<Event> = new EventEmitter();
 
+    @HostBinding('attr.tabindex')
+    _hostIndex = 0;
+
     /** The template to be used when this tab is selected. Defaults to the content of this tab component.
      * Not used when the tab set uses routing. */
     @ViewChild('tabContent', {static: false})
@@ -52,7 +55,11 @@ export class TabComponent implements AfterContentInit {
         }
     }
 
-    tabClickHandler(event: MouseEvent) {
+    @HostListener('keydown.enter', ['$event']) _onEnter($event) {
+        this.tabClickHandler($event);
+    }
+
+    tabClickHandler(event: Event) {
         // Prevent a tab anchor click from also calling the router on the host element
         event.preventDefault();
         event.stopPropagation();

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -177,16 +177,6 @@ ol {
     margin: 20px 0;
 }
 
-.demo-button {
-    margin-top: 10px !important;
-    margin-right: 10px !important;
-}
-
-.pipe-output {
-    font-weight: 600px;
-    font-size: 22px;
-}
-
 table {
     width: 100%;
     @include fontSize(13px);
@@ -253,4 +243,19 @@ table {
 
 .overflow-visible > .hc-horizontal-tab-container > .hc-tab-content-horizontal {
     overflow: visible !important;
+}
+
+// global demo styles
+.demo-button {
+    margin-top: 10px !important;
+    margin-right: 10px !important;
+}
+
+hc-example-viewer .hc-tab-content-horizontal {
+    padding: 3px;
+}
+
+.pipe-output {
+    font-weight: 600px;
+    font-size: 22px;
 }


### PR DESCRIPTION
Started by just adding focus/hover states to form controls. I'm not married to the styles by any means, but they're pretty consistent and simple. Check them out and see what you think. They'll be easy to change now that they're all in there. Some components, like inputs and checkboxes wouldn't really accept "focus" before.

Also ended up adding keyboard accessibility features all over, so most every component can now be operated just using the keyboard. I'd recommend going component by component and tabbing around to see how things feel, and compare it to the prod site.